### PR TITLE
feat: add window handler callback

### DIFF
--- a/projects/angular-simple-oidc/src/lib/auth.service.ts
+++ b/projects/angular-simple-oidc/src/lib/auth.service.ts
@@ -2,58 +2,70 @@ import { Injectable, Inject } from '@angular/core';
 import { TokenStorageService } from './token-storage.service';
 import { map, tap, switchMap, take, shareReplay } from 'rxjs/operators';
 import { OidcCodeFlowClient } from './oidc-code-flow-client.service';
-import { TokenHelperService, DecodedIdentityToken, LocalState, TokenRequestResult } from 'angular-simple-oidc/core';
+import {
+    TokenHelperService,
+    DecodedIdentityToken,
+    LocalState,
+    TokenRequestResult
+} from 'angular-simple-oidc/core';
 import { RefreshTokenClient } from './refresh-token-client.service';
 import { EndSessionClientService } from './end-session-client.service';
 import { Observable } from 'rxjs';
 import { AUTH_CONFIG_SERVICE } from './providers';
 import { ConfigService } from 'angular-simple-oidc/config';
 import { AuthConfig } from './config/models';
-import { EventsService, SimpleOidcEvent, SimpleOidcErrorEvent } from 'angular-simple-oidc/events';
+import {
+    EventsService,
+    SimpleOidcEvent,
+    SimpleOidcErrorEvent
+} from 'angular-simple-oidc/events';
 import { StartCodeFlowParameters, ClaimCollection } from './models';
 import { UserInfoClientService } from './user-info-client.service';
 import { filterInstanceOf } from 'angular-simple-oidc/operators';
 import { TokensReadyEvent } from './auth.events';
+import { LogoutFlowParameters } from './models';
 
 @Injectable()
 export class AuthService {
-
     public get isLoggedIn$(): Observable<boolean> {
-        return this.tokenStorage.currentState$
-            .pipe(
-                map(({ accessToken, accessTokenExpiration }) => {
-                    if (!accessToken || this.tokenHelper.isTokenExpired(accessTokenExpiration)) {
-                        return false;
-                    }
+        return this.tokenStorage.currentState$.pipe(
+            map(({ accessToken, accessTokenExpiration }) => {
+                if (
+                    !accessToken ||
+                    this.tokenHelper.isTokenExpired(accessTokenExpiration)
+                ) {
+                    return false;
+                }
 
-                    return true;
-                })
-            );
+                return true;
+            })
+        );
     }
 
     public get accessToken$(): Observable<string> {
-        return this.tokenStorage.currentState$
-            .pipe(map(s => s.accessToken));
+        return this.tokenStorage.currentState$.pipe(map((s) => s.accessToken));
     }
 
     public get tokenExpiration$(): Observable<Date> {
-        return this.tokenStorage.currentState$
-            .pipe(map(s => new Date(s.accessTokenExpiration)));
+        return this.tokenStorage.currentState$.pipe(
+            map((s) => new Date(s.accessTokenExpiration))
+        );
     }
 
     public get refreshToken$(): Observable<string> {
-        return this.tokenStorage.currentState$
-            .pipe(map(s => s.refreshToken));
+        return this.tokenStorage.currentState$.pipe(map((s) => s.refreshToken));
     }
 
     public get identityToken$(): Observable<string> {
-        return this.tokenStorage.currentState$
-            .pipe(map(s => s.identityToken));
+        return this.tokenStorage.currentState$.pipe(
+            map((s) => s.identityToken)
+        );
     }
 
     public get identityTokenDecoded$(): Observable<DecodedIdentityToken> {
-        return this.tokenStorage.currentState$
-            .pipe(map(s => s.decodedIdentityToken));
+        return this.tokenStorage.currentState$.pipe(
+            map((s) => s.decodedIdentityToken)
+        );
     }
 
     public readonly userInfo$: Observable<ClaimCollection> = this.events$.pipe(
@@ -80,24 +92,34 @@ export class AuthService {
         protected readonly config: ConfigService<AuthConfig>,
         protected readonly events: EventsService,
         protected readonly userInfoClient: UserInfoClientService
-    ) { }
+    ) {}
 
-    public startCodeFlow(options?: StartCodeFlowParameters): Observable<LocalState> {
-        return this.oidcClient.startCodeFlow(options)
-            .pipe(tap({ error: e => this.events.dispatchError(e) }));
+    public startCodeFlow(
+        options?: StartCodeFlowParameters
+    ): Observable<LocalState> {
+        return this.oidcClient
+            .startCodeFlow(options)
+            .pipe(tap({ error: (e) => this.events.dispatchError(e) }));
     }
 
     public refreshAccessToken(): Observable<TokenRequestResult> {
-        return this.refreshTokenClient.requestTokenWithRefreshCode()
-            .pipe(tap({ error: e => this.events.dispatchError(e) }));
+        return this.refreshTokenClient
+            .requestTokenWithRefreshCode()
+            .pipe(tap({ error: (e) => this.events.dispatchError(e) }));
     }
 
-    public endSession(postLogoutRedirectUri?: string) {
-        return this.config.current$
-            .pipe(
-                take(1),
-                switchMap(config => this.endSessionClient.logoutWithRedirect(postLogoutRedirectUri || config.baseUrl)),
-                tap({ error: e => this.events.dispatchError(e) }),
-            );
+    public endSession(options?: LogoutFlowParameters) {
+        return this.config.current$.pipe(
+            take(1),
+            switchMap((config) => {
+                const opts: LogoutFlowParameters = {
+                    ...options
+                };
+                opts.postLogoutRedirectUri =
+                    opts.postLogoutRedirectUri || config.baseUrl;
+                return this.endSessionClient.logoutWithRedirect(opts);
+            }),
+            tap({ error: (e) => this.events.dispatchError(e) })
+        );
     }
 }

--- a/projects/angular-simple-oidc/src/lib/end-session-client.service.spec.ts
+++ b/projects/angular-simple-oidc/src/lib/end-session-client.service.spec.ts
@@ -1,6 +1,10 @@
 import { TestBed, fakeAsync, flush } from '@angular/core/testing';
 import { OidcDiscoveryDocClient } from './discovery-document/oidc-discovery-doc-client.service';
-import { DiscoveryDocument, LocalState, TokenUrlService } from 'angular-simple-oidc/core';
+import {
+    DiscoveryDocument,
+    LocalState,
+    TokenUrlService
+} from 'angular-simple-oidc/core';
 import { of } from 'rxjs';
 import { EndSessionClientService } from './end-session-client.service';
 import { WINDOW_REF } from './providers';
@@ -20,9 +24,15 @@ describe('EndSessionClientService', () => {
 
     beforeEach(() => {
         windowSpy = jasmine.createSpyObj('window', ['location']);
-        discoveryDocClientSpy = jasmine.createSpyObj('OidcDiscoveryDocClient', ['current$']);
-        tokenUrlSpy = jasmine.createSpyObj('TokenUrlService', ['createEndSessionUrl']);
-        tokenStorageSpy = jasmine.createSpyObj('TokenStorageService', ['removeAll']);
+        discoveryDocClientSpy = jasmine.createSpyObj('OidcDiscoveryDocClient', [
+            'current$'
+        ]);
+        tokenUrlSpy = jasmine.createSpyObj('TokenUrlService', [
+            'createEndSessionUrl'
+        ]);
+        tokenStorageSpy = jasmine.createSpyObj('TokenStorageService', [
+            'removeAll'
+        ]);
         eventsSpy = jasmine.createSpyObj('EventsService', ['dispatch']);
 
         TestBed.configureTestingModule({
@@ -33,7 +43,7 @@ describe('EndSessionClientService', () => {
                 },
                 {
                     provide: OidcDiscoveryDocClient,
-                    useValue: discoveryDocClientSpy,
+                    useValue: discoveryDocClientSpy
                 },
                 {
                     provide: TokenUrlService,
@@ -48,18 +58,28 @@ describe('EndSessionClientService', () => {
                     useValue: eventsSpy
                 },
                 EndSessionClientService
-            ],
+            ]
         });
 
-        discoveryDocSpy = spyOnGet(TestBed.get(OidcDiscoveryDocClient) as OidcDiscoveryDocClient, 'current$');
-        discoveryDocSpy.and.returnValue(of({
-            end_session_endpoint: 'http://end-session'
-        } as Partial<DiscoveryDocument>));
+        discoveryDocSpy = spyOnGet(
+            TestBed.get(OidcDiscoveryDocClient) as OidcDiscoveryDocClient,
+            'current$'
+        );
+        discoveryDocSpy.and.returnValue(
+            of({
+                end_session_endpoint: 'http://end-session'
+            } as Partial<DiscoveryDocument>)
+        );
 
-        localStateSpy = spyOnGet(TestBed.get(TokenStorageService) as TokenStorageService, 'currentState$');
-        localStateSpy.and.returnValue(of({
-            identityToken: 'id-token'
-        } as Partial<LocalState>));
+        localStateSpy = spyOnGet(
+            TestBed.get(TokenStorageService) as TokenStorageService,
+            'currentState$'
+        );
+        localStateSpy.and.returnValue(
+            of({
+                identityToken: 'id-token'
+            } as Partial<LocalState>)
+        );
 
         tokenStorageSpy.removeAll.and.returnValue(of({} as any));
 
@@ -79,7 +99,8 @@ describe('EndSessionClientService', () => {
                 url: 'http://end-it'
             });
 
-            endSessionClient.logoutWithRedirect(postLogoutUri)
+            endSessionClient
+                .logoutWithRedirect({ postLogoutRedirectUri: postLogoutUri })
                 .subscribe();
             flush();
 
@@ -94,7 +115,8 @@ describe('EndSessionClientService', () => {
                 url: 'http://end-it'
             });
 
-            endSessionClient.logoutWithRedirect(postLogoutUri)
+            endSessionClient
+                .logoutWithRedirect({ postLogoutRedirectUri: postLogoutUri })
                 .subscribe();
             flush();
 
@@ -110,13 +132,36 @@ describe('EndSessionClientService', () => {
                 url: expected
             });
 
-            endSessionClient.logoutWithRedirect(postLogoutUri)
+            endSessionClient
+                .logoutWithRedirect({ postLogoutRedirectUri: postLogoutUri })
                 .subscribe();
             flush();
 
             expect(windowSpy.location.href).toEqual(expected);
         }));
 
-    });
+        it('calls the provided window handler', fakeAsync(() => {
+            const postLogoutUri = 'post-logout-uri';
+            const observer = { callback: (url: string) => {} };
 
+            spyOn(observer, 'callback');
+
+            const expected = 'http://end-it';
+            tokenUrlSpy.createEndSessionUrl.and.returnValue({
+                state: 'state',
+                url: expected
+            });
+
+            endSessionClient
+                .logoutWithRedirect({
+                    postLogoutRedirectUri: postLogoutUri,
+                    openWindowHandler: observer.callback
+                })
+                .subscribe();
+            flush();
+
+            expect(observer.callback).toHaveBeenCalled();
+            expect(observer.callback).toHaveBeenCalledWith(expected);
+        }));
+    });
 });

--- a/projects/angular-simple-oidc/src/lib/end-session-client.service.ts
+++ b/projects/angular-simple-oidc/src/lib/end-session-client.service.ts
@@ -7,39 +7,54 @@ import { TokenStorageService } from './token-storage.service';
 import { combineLatest } from 'rxjs';
 import { switchTap } from 'angular-simple-oidc/operators';
 import { EventsService, SimpleOidcInfoEvent } from 'angular-simple-oidc/events';
+import { LogoutFlowParameters } from './models';
 
 // @dynamic
 @Injectable()
 export class EndSessionClientService {
-
     constructor(
         @Inject(WINDOW_REF)
         protected readonly window: Window,
         protected readonly discoveryDocumentClient: OidcDiscoveryDocClient,
         protected readonly tokenUrl: TokenUrlService,
         protected readonly tokenStorage: TokenStorageService,
-        protected readonly events: EventsService,
-    ) { }
+        protected readonly events: EventsService
+    ) {}
 
-    public logoutWithRedirect(postLogoutRedirectUri?: string) {
+    public logoutWithRedirect(options: LogoutFlowParameters = {}) {
         const doc$ = this.discoveryDocumentClient.current$;
         const localState$ = this.tokenStorage.currentState$;
+        const opts: LogoutFlowParameters = {
+            ...options
+        };
 
-        return combineLatest(doc$, localState$)
-            .pipe(
-                take(1),
-                map(([doc, localState]) => this.tokenUrl.createEndSessionUrl(doc.end_session_endpoint, {
+        return combineLatest(doc$, localState$).pipe(
+            take(1),
+            map(([doc, localState]) =>
+                this.tokenUrl.createEndSessionUrl(doc.end_session_endpoint, {
                     idTokenHint: localState.identityToken,
-                    postLogoutRedirectUri
-                })),
-                switchTap(() => {
-                    this.events.dispatch(new SimpleOidcInfoEvent('Deleting Local Session'));
-                    return this.tokenStorage.removeAll();
-                }),
-                tap(({ url }) => {
-                    this.events.dispatch(new SimpleOidcInfoEvent('Redirecting to End Session Endpoint', url));
+                    postLogoutRedirectUri: opts.postLogoutRedirectUri
+                })
+            ),
+            switchTap(() => {
+                this.events.dispatch(
+                    new SimpleOidcInfoEvent('Deleting Local Session')
+                );
+                return this.tokenStorage.removeAll();
+            }),
+            tap(({ url }) => {
+                this.events.dispatch(
+                    new SimpleOidcInfoEvent(
+                        'Redirecting to End Session Endpoint',
+                        url
+                    )
+                );
+                if (opts.openWindowHandler) {
+                    opts.openWindowHandler(url);
+                } else {
                     this.window.location.href = url;
-                }),
-            );
+                }
+            })
+        );
     }
 }

--- a/projects/angular-simple-oidc/src/lib/models.ts
+++ b/projects/angular-simple-oidc/src/lib/models.ts
@@ -1,4 +1,4 @@
-export interface StartCodeFlowParameters {
+export interface StartCodeFlowParameters extends WindowHandler {
     /**
      * The URL to navigate (using the Router) after
      * the token callback has been execute successfully.
@@ -8,5 +8,19 @@ export interface StartCodeFlowParameters {
 }
 
 export interface ClaimCollection {
-    [key: string]: string | (string[]);
+    [key: string]: string | string[];
+}
+
+export interface LogoutFlowParameters extends WindowHandler {
+    /**
+     * The URL to navigate after the session is closed.
+     */
+    postLogoutRedirectUri?: string;
+}
+
+export interface WindowHandler {
+    /**
+     * Window handler for open the url.
+     */
+    openWindowHandler?: (url: string) => void;
 }

--- a/projects/angular-simple-oidc/src/lib/oidc-code-flow-client.service.spec.ts
+++ b/projects/angular-simple-oidc/src/lib/oidc-code-flow-client.service.spec.ts
@@ -47,30 +47,37 @@ describe('OidcCodeFlowClientService', () => {
             disableIdTokenIATValidation: false,
             idTokenIATOffsetAllowed: 3000
         },
-        baseUrl: 'http://base-url/',
+        baseUrl: 'http://base-url/'
     };
 
     beforeEach(() => {
         windowSpy = jasmine.createSpyObj('window', ['location', 'history']);
         authConfigSpy = jasmine.createSpyObj('AuthConfigService', ['current$']);
-        discoveryDocClientSpy = jasmine.createSpyObj('OidcDiscoveryDocClient', ['current$']);
+        discoveryDocClientSpy = jasmine.createSpyObj('OidcDiscoveryDocClient', [
+            'current$'
+        ]);
         tokenStorageSpy = jasmine.createSpyObj('TokenStorageService', [
             'storePreAuthorizationState',
             'storeAuthorizationCode',
             'clearPreAuthorizationState',
             'storeTokens',
-            'storeOriginalIdToken']);
+            'storeOriginalIdToken'
+        ]);
         tokenUrlSpy = jasmine.createSpyObj('TokenUrlService', [
             'createAuthorizeUrl',
             'parseAuthorizeCallbackParamsFromUrl',
-            'createAuthorizationCodeRequestPayload']);
+            'createAuthorizationCodeRequestPayload'
+        ]);
         tokenValidationSpy = jasmine.createSpyObj('TokenValidationService', [
             'validateIdTokenFormat',
             'validateIdToken',
             'validateAccessToken',
             'validateAuthorizeCallbackFormat',
-            'validateAuthorizeCallbackState']);
-        tokenEndpointSpy = jasmine.createSpyObj('TokenEndpointClientService', ['call']);
+            'validateAuthorizeCallbackState'
+        ]);
+        tokenEndpointSpy = jasmine.createSpyObj('TokenEndpointClientService', [
+            'call'
+        ]);
         eventsSpy = jasmine.createSpyObj('EventsService', ['dispatch']);
 
         TestBed.configureTestingModule({
@@ -85,15 +92,15 @@ describe('OidcCodeFlowClientService', () => {
                 },
                 {
                     provide: OidcDiscoveryDocClient,
-                    useValue: discoveryDocClientSpy,
+                    useValue: discoveryDocClientSpy
                 },
                 {
                     provide: TokenStorageService,
-                    useValue: tokenStorageSpy,
+                    useValue: tokenStorageSpy
                 },
                 {
                     provide: TokenValidationService,
-                    useValue: tokenValidationSpy,
+                    useValue: tokenValidationSpy
                 },
                 {
                     provide: TokenUrlService,
@@ -108,36 +115,50 @@ describe('OidcCodeFlowClientService', () => {
                     useValue: eventsSpy
                 },
                 OidcCodeFlowClient
-            ],
+            ]
         });
 
-        discoveryDocSpy = spyOnGet(TestBed.get(OidcDiscoveryDocClient) as OidcDiscoveryDocClient, 'current$');
+        discoveryDocSpy = spyOnGet(
+            TestBed.get(OidcDiscoveryDocClient) as OidcDiscoveryDocClient,
+            'current$'
+        );
         discoveryDocSpy.and.returnValue(of());
 
-        jwtKeysSpy = spyOnGet(TestBed.get(OidcDiscoveryDocClient) as OidcDiscoveryDocClient, 'jwtKeys$');
+        jwtKeysSpy = spyOnGet(
+            TestBed.get(OidcDiscoveryDocClient) as OidcDiscoveryDocClient,
+            'jwtKeys$'
+        );
         jwtKeysSpy.and.returnValue(of({}));
 
         codeFlowClient = TestBed.get(OidcCodeFlowClient);
 
-        const configSpy = spyOnGet(TestBed.get(AUTH_CONFIG_SERVICE) as ConfigService<AuthConfig>, 'current$');
+        const configSpy = spyOnGet(
+            TestBed.get(AUTH_CONFIG_SERVICE) as ConfigService<AuthConfig>,
+            'current$'
+        );
         configSpy.and.returnValue(of(config));
 
-        windowLocationSpy = spyOnGet(TestBed.get(WINDOW_REF) as Window, 'location');
+        windowLocationSpy = spyOnGet(
+            TestBed.get(WINDOW_REF) as Window,
+            'location'
+        );
         windowLocationSpy.and.returnValue({ href: config.baseUrl });
-        spyOnGet(TestBed.get(WINDOW_REF) as Window, 'history').and.returnValue({ pushState: () => { } });
+        spyOnGet(TestBed.get(WINDOW_REF) as Window, 'history').and.returnValue({
+            pushState: () => {}
+        });
 
-        stateSpy = spyOnGet(TestBed.get(TokenStorageService) as TokenStorageService, 'currentState$');
+        stateSpy = spyOnGet(
+            TestBed.get(TokenStorageService) as TokenStorageService,
+            'currentState$'
+        );
     });
 
     it('should create', () => {
         expect(codeFlowClient).toBeTruthy();
     });
 
-
     describe('generateCodeFlowMetadata', () => {
-
         it('Should use Discovery Document for obtaining authorize URL', fakeAsync(() => {
-
             const doc: Partial<DiscoveryDocument> = {
                 authorization_endpoint: 'http://idp/authorize'
             };
@@ -158,26 +179,27 @@ describe('OidcCodeFlowClientService', () => {
             const idTokenHint = 'id-token-hint';
             const prompt = 'prompt';
 
-            codeFlowClient.generateCodeFlowMetadata({ redirectUri, idTokenHint, prompt })
+            codeFlowClient
+                .generateCodeFlowMetadata({ redirectUri, idTokenHint, prompt })
                 .subscribe();
             flush();
 
-            expect(tokenUrlSpy.createAuthorizeUrl)
-                .toHaveBeenCalledWith(doc.authorization_endpoint, {
+            expect(tokenUrlSpy.createAuthorizeUrl).toHaveBeenCalledWith(
+                doc.authorization_endpoint,
+                {
                     clientId: config.clientId,
                     responseType: 'code',
                     scope: config.scope,
                     redirectUri: redirectUri,
                     idTokenHint: idTokenHint,
-                    prompt: prompt,
-                });
+                    prompt: prompt
+                }
+            );
         }));
     });
 
     describe('Start Code Flow', () => {
-
         it('Should store pre authorization request using storage service', fakeAsync(() => {
-
             const doc: Partial<DiscoveryDocument> = {
                 authorization_endpoint: 'http://idp/authorize'
             };
@@ -196,28 +218,29 @@ describe('OidcCodeFlowClientService', () => {
 
             tokenUrlSpy.createAuthorizeUrl.and.returnValue(urlResult);
 
-            codeFlowClient.startCodeFlow()
-                .subscribe();
+            codeFlowClient.startCodeFlow().subscribe();
             flush();
 
-            expect(tokenStorageSpy.storePreAuthorizationState)
-                .toHaveBeenCalledWith({
-                    nonce: urlResult.nonce,
-                    state: urlResult.state,
-                    codeVerifier: urlResult.codeVerifier,
-                    preRedirectUrl: config.baseUrl
-                });
+            expect(
+                tokenStorageSpy.storePreAuthorizationState
+            ).toHaveBeenCalledWith({
+                nonce: urlResult.nonce,
+                state: urlResult.state,
+                codeVerifier: urlResult.codeVerifier,
+                preRedirectUrl: config.baseUrl
+            });
         }));
 
         it('Should change the URL after storing pre-auth state', fakeAsync(() => {
-
             const doc: Partial<DiscoveryDocument> = {
                 authorization_endpoint: 'http://idp/authorize'
             };
 
             discoveryDocSpy.and.returnValue(of(doc));
 
-            tokenStorageSpy.storePreAuthorizationState.and.returnValue(of({} as any));
+            tokenStorageSpy.storePreAuthorizationState.and.returnValue(
+                of({} as any)
+            );
 
             const urlResult = {
                 codeChallenge: 'challenge',
@@ -229,26 +252,30 @@ describe('OidcCodeFlowClientService', () => {
 
             tokenUrlSpy.createAuthorizeUrl.and.returnValue(urlResult);
 
-            const changeUrlSpy = spyOn(codeFlowClient as any, 'redirectToUrl')
-                .and.returnValue(null);
+            const changeUrlSpy = spyOn(
+                codeFlowClient as any,
+                'redirectToUrl'
+            ).and.returnValue(null);
 
-            codeFlowClient.startCodeFlow()
-                .subscribe();
+            codeFlowClient.startCodeFlow().subscribe();
             flush();
 
-            expect(tokenStorageSpy.storePreAuthorizationState).toHaveBeenCalled();
+            expect(
+                tokenStorageSpy.storePreAuthorizationState
+            ).toHaveBeenCalled();
             expect(changeUrlSpy).toHaveBeenCalledWith(urlResult.url);
         }));
 
         it('Should store provided return URL in storage', fakeAsync(() => {
-
             const doc: Partial<DiscoveryDocument> = {
                 authorization_endpoint: 'http://idp/authorize'
             };
 
             discoveryDocSpy.and.returnValue(of(doc));
 
-            tokenStorageSpy.storePreAuthorizationState.and.returnValue(of({} as any));
+            tokenStorageSpy.storePreAuthorizationState.and.returnValue(
+                of({} as any)
+            );
 
             const urlResult = {
                 codeChallenge: 'challenge',
@@ -262,13 +289,16 @@ describe('OidcCodeFlowClientService', () => {
 
             const returnUrl = 'http://return-url';
 
-            codeFlowClient.startCodeFlow({
-                returnUrlAfterCallback: returnUrl
-            })
+            codeFlowClient
+                .startCodeFlow({
+                    returnUrlAfterCallback: returnUrl
+                })
                 .subscribe();
             flush();
 
-            expect(tokenStorageSpy.storePreAuthorizationState).toHaveBeenCalledWith({
+            expect(
+                tokenStorageSpy.storePreAuthorizationState
+            ).toHaveBeenCalledWith({
                 nonce: urlResult.nonce,
                 state: urlResult.state,
                 codeVerifier: urlResult.codeVerifier,
@@ -277,14 +307,15 @@ describe('OidcCodeFlowClientService', () => {
         }));
 
         it('Should default to current url for return url', fakeAsync(() => {
-
             const doc: Partial<DiscoveryDocument> = {
                 authorization_endpoint: 'http://idp/authorize'
             };
 
             discoveryDocSpy.and.returnValue(of(doc));
 
-            tokenStorageSpy.storePreAuthorizationState.and.returnValue(of({} as any));
+            tokenStorageSpy.storePreAuthorizationState.and.returnValue(
+                of({} as any)
+            );
 
             const urlResult = {
                 codeChallenge: 'challenge',
@@ -298,107 +329,135 @@ describe('OidcCodeFlowClientService', () => {
             const currentLocation = 'http://current-location';
             windowLocationSpy.and.returnValue({ href: currentLocation });
 
-            codeFlowClient.startCodeFlow()
-                .subscribe();
+            codeFlowClient.startCodeFlow().subscribe();
             flush();
 
-            expect(tokenStorageSpy.storePreAuthorizationState).toHaveBeenCalledWith({
+            expect(
+                tokenStorageSpy.storePreAuthorizationState
+            ).toHaveBeenCalledWith({
                 nonce: urlResult.nonce,
                 state: urlResult.state,
                 codeVerifier: urlResult.codeVerifier,
                 preRedirectUrl: currentLocation
             });
         }));
+
+        it('Should call the provided window handler', fakeAsync(() => {
+            const observer = { callback: (url: string) => {} };
+            const doc: Partial<DiscoveryDocument> = {
+                authorization_endpoint: 'http://idp/authorize'
+            };
+
+            spyOn(observer, 'callback');
+
+            discoveryDocSpy.and.returnValue(of(doc));
+
+            tokenStorageSpy.storePreAuthorizationState.and.returnValue(
+                of({} as any)
+            );
+
+            const urlResult = {
+                codeChallenge: 'challenge',
+                codeVerifier: 'verifier',
+                nonce: 'nonce',
+                state: 'state',
+                url: 'url'
+            };
+
+            tokenUrlSpy.createAuthorizeUrl.and.returnValue(urlResult);
+
+            codeFlowClient
+                .startCodeFlow({ openWindowHandler: observer.callback })
+                .subscribe();
+            flush();
+
+            expect(observer.callback).toHaveBeenCalled();
+            expect(observer.callback).toHaveBeenCalledWith(urlResult.url);
+        }));
     });
 
     describe('Code Flow Callback', () => {
-
         it('should parse params from URL using helper', fakeAsync(() => {
-
             const state = 'state';
             const code = 'code';
             const sessionState = 'session-state';
             const error = null;
 
             tokenStorageSpy.storeAuthorizationCode.and.returnValue(of());
-            tokenUrlSpy.parseAuthorizeCallbackParamsFromUrl
-                .and.returnValue({
-                    code,
-                    state,
-                    sessionState,
-                    error
-                });
+            tokenUrlSpy.parseAuthorizeCallbackParamsFromUrl.and.returnValue({
+                code,
+                state,
+                sessionState,
+                error
+            });
 
             stateSpy.and.returnValue(of({}));
 
-            codeFlowClient.currentWindowCodeFlowCallback()
-                .subscribe();
+            codeFlowClient.currentWindowCodeFlowCallback().subscribe();
             flush();
 
-            expect(tokenUrlSpy.parseAuthorizeCallbackParamsFromUrl).toHaveBeenCalledWith(config.baseUrl);
-
+            expect(
+                tokenUrlSpy.parseAuthorizeCallbackParamsFromUrl
+            ).toHaveBeenCalledWith(config.baseUrl);
         }));
 
         it('should throw if url is invalid', fakeAsync(() => {
+            tokenUrlSpy.parseAuthorizeCallbackParamsFromUrl.and.throwError(
+                'error'
+            );
 
-            tokenUrlSpy.parseAuthorizeCallbackParamsFromUrl
-                .and.throwError('error');
-
-            stateSpy.and.returnValue(of({
-                state: null
-            }));
+            stateSpy.and.returnValue(
+                of({
+                    state: null
+                })
+            );
 
             expect(() => {
-                codeFlowClient.currentWindowCodeFlowCallback()
-                    .subscribe();
+                codeFlowClient.currentWindowCodeFlowCallback().subscribe();
                 flush();
             }).toThrowError(AuthorizationCallbackFormatError);
 
-            expect(tokenUrlSpy.parseAuthorizeCallbackParamsFromUrl).toHaveBeenCalledWith(config.baseUrl);
-
+            expect(
+                tokenUrlSpy.parseAuthorizeCallbackParamsFromUrl
+            ).toHaveBeenCalledWith(config.baseUrl);
         }));
 
         it('should validate URL parameters using validation service', fakeAsync(() => {
-
             const state = 'state';
             const code = 'code';
             const sessionState = 'session-state';
             const error = null;
 
             tokenStorageSpy.storeAuthorizationCode.and.returnValue(of());
-            tokenUrlSpy.parseAuthorizeCallbackParamsFromUrl
-                .and.returnValue({
-                    code,
-                    state,
-                    sessionState,
-                    error
-                });
+            tokenUrlSpy.parseAuthorizeCallbackParamsFromUrl.and.returnValue({
+                code,
+                state,
+                sessionState,
+                error
+            });
 
             stateSpy.and.returnValue(of({}));
 
-            codeFlowClient.currentWindowCodeFlowCallback()
-                .subscribe();
+            codeFlowClient.currentWindowCodeFlowCallback().subscribe();
             flush();
 
-            expect(tokenValidationSpy.validateAuthorizeCallbackFormat)
-                .toHaveBeenCalledWith(code, state, error, config.baseUrl);
-
+            expect(
+                tokenValidationSpy.validateAuthorizeCallbackFormat
+            ).toHaveBeenCalledWith(code, state, error, config.baseUrl);
         }));
 
         it('should validate local state using validation service', fakeAsync(() => {
-
             const state = 'state';
             const code = 'code';
             const sessionState = 'session-state';
             const error = null;
 
-            tokenUrlSpy.parseAuthorizeCallbackParamsFromUrl
-                .and.returnValue({
-                    code,
-                    state,
-                    sessionState,
-                    error
-                });
+            tokenUrlSpy.parseAuthorizeCallbackParamsFromUrl.and.returnValue({
+                code,
+                state,
+                sessionState,
+                error
+            });
 
             const localState = {
                 state: undefined
@@ -408,27 +467,26 @@ describe('OidcCodeFlowClientService', () => {
 
             tokenStorageSpy.storeAuthorizationCode.and.returnValue(of());
 
-            codeFlowClient.currentWindowCodeFlowCallback()
-                .subscribe();
+            codeFlowClient.currentWindowCodeFlowCallback().subscribe();
             flush();
 
-            expect(tokenValidationSpy.validateAuthorizeCallbackState).toHaveBeenCalledWith(localState.state, state);
+            expect(
+                tokenValidationSpy.validateAuthorizeCallbackState
+            ).toHaveBeenCalledWith(localState.state, state);
         }));
 
         it('should store code using storage service', fakeAsync(() => {
-
             const state = 'state';
             const code = 'code';
             const sessionState = 'session-state';
             const error = null;
 
-            tokenUrlSpy.parseAuthorizeCallbackParamsFromUrl
-                .and.returnValue({
-                    code,
-                    state,
-                    sessionState,
-                    error
-                });
+            tokenUrlSpy.parseAuthorizeCallbackParamsFromUrl.and.returnValue({
+                code,
+                state,
+                sessionState,
+                error
+            });
 
             const localState = {};
 
@@ -436,30 +494,29 @@ describe('OidcCodeFlowClientService', () => {
 
             tokenStorageSpy.storeAuthorizationCode.and.returnValue(of());
 
-            codeFlowClient.currentWindowCodeFlowCallback()
-                .subscribe();
+            codeFlowClient.currentWindowCodeFlowCallback().subscribe();
             flush();
 
-            expect(tokenStorageSpy.storeAuthorizationCode).toHaveBeenCalledWith(code, sessionState);
+            expect(tokenStorageSpy.storeAuthorizationCode).toHaveBeenCalledWith(
+                code,
+                sessionState
+            );
         }));
-
     });
 
     describe('Request Token using Authorization Code', () => {
         it('should use token url to generate token endpoint url', fakeAsync(() => {
-
             const state = 'state';
             const code = 'code';
             const sessionState = 'session-state';
             const error = null;
 
-            tokenUrlSpy.parseAuthorizeCallbackParamsFromUrl
-                .and.returnValue({
-                    code,
-                    state,
-                    sessionState,
-                    error
-                });
+            tokenUrlSpy.parseAuthorizeCallbackParamsFromUrl.and.returnValue({
+                code,
+                state,
+                sessionState,
+                error
+            });
 
             const localState: Partial<LocalState> = {
                 authorizationCode: code,
@@ -468,15 +525,18 @@ describe('OidcCodeFlowClientService', () => {
 
             stateSpy.and.returnValue(of(localState));
 
-            tokenStorageSpy.storeAuthorizationCode.and.returnValue(of(localState as any));
+            tokenStorageSpy.storeAuthorizationCode.and.returnValue(
+                of(localState as any)
+            );
 
             tokenEndpointSpy.call.and.returnValue(of());
 
-            codeFlowClient.currentWindowCodeFlowCallback()
-                .subscribe();
+            codeFlowClient.currentWindowCodeFlowCallback().subscribe();
             flush();
 
-            expect(tokenUrlSpy.createAuthorizationCodeRequestPayload).toHaveBeenCalledWith({
+            expect(
+                tokenUrlSpy.createAuthorizationCodeRequestPayload
+            ).toHaveBeenCalledWith({
                 clientId: config.clientId,
                 clientSecret: config.clientSecret,
                 scope: config.scope,
@@ -487,19 +547,17 @@ describe('OidcCodeFlowClientService', () => {
         }));
 
         it('should validate tokens using validation service', fakeAsync(() => {
-
             const state = 'state';
             const code = 'code';
             const sessionState = 'session-state';
             const error = null;
 
-            tokenUrlSpy.parseAuthorizeCallbackParamsFromUrl
-                .and.returnValue({
-                    code,
-                    state,
-                    sessionState,
-                    error
-                });
+            tokenUrlSpy.parseAuthorizeCallbackParamsFromUrl.and.returnValue({
+                code,
+                state,
+                sessionState,
+                error
+            });
 
             const doc: Partial<DiscoveryDocument> = {};
 
@@ -518,7 +576,9 @@ describe('OidcCodeFlowClientService', () => {
                 codeVerifier: 'verifier'
             };
 
-            tokenStorageSpy.storeAuthorizationCode.and.returnValue(of(freshState as any));
+            tokenStorageSpy.storeAuthorizationCode.and.returnValue(
+                of(freshState as any)
+            );
 
             tokenStorageSpy.clearPreAuthorizationState.and.returnValue(of());
 
@@ -534,8 +594,7 @@ describe('OidcCodeFlowClientService', () => {
 
             tokenEndpointSpy.call.and.returnValue(of(tokenResponse));
 
-            codeFlowClient.currentWindowCodeFlowCallback()
-                .subscribe();
+            codeFlowClient.currentWindowCodeFlowCallback().subscribe();
             flush();
 
             expect(tokenValidationSpy.validateIdToken).toHaveBeenCalledWith(
@@ -555,19 +614,17 @@ describe('OidcCodeFlowClientService', () => {
         }));
 
         it('should clear pre auth state and store new state', fakeAsync(() => {
-
             const state = 'state';
             const code = 'code';
             const sessionState = 'session-state';
             const error = null;
 
-            tokenUrlSpy.parseAuthorizeCallbackParamsFromUrl
-                .and.returnValue({
-                    code,
-                    state,
-                    sessionState,
-                    error
-                });
+            tokenUrlSpy.parseAuthorizeCallbackParamsFromUrl.and.returnValue({
+                code,
+                state,
+                sessionState,
+                error
+            });
 
             const doc: Partial<DiscoveryDocument> = {};
 
@@ -586,9 +643,13 @@ describe('OidcCodeFlowClientService', () => {
                 codeVerifier: 'verifier'
             };
 
-            tokenStorageSpy.storeAuthorizationCode.and.returnValue(of(freshState as any));
+            tokenStorageSpy.storeAuthorizationCode.and.returnValue(
+                of(freshState as any)
+            );
 
-            tokenStorageSpy.clearPreAuthorizationState.and.returnValue(of({} as any));
+            tokenStorageSpy.clearPreAuthorizationState.and.returnValue(
+                of({} as any)
+            );
             tokenStorageSpy.storeTokens.and.returnValue(of({} as any));
             tokenStorageSpy.storeOriginalIdToken.and.returnValue(of({} as any));
 
@@ -604,32 +665,37 @@ describe('OidcCodeFlowClientService', () => {
 
             tokenEndpointSpy.call.and.returnValue(of(tokenResponse));
 
-            codeFlowClient.currentWindowCodeFlowCallback()
-                .subscribe();
+            codeFlowClient.currentWindowCodeFlowCallback().subscribe();
             flush();
 
-            expect(tokenStorageSpy.clearPreAuthorizationState).toHaveBeenCalled();
+            expect(
+                tokenStorageSpy.clearPreAuthorizationState
+            ).toHaveBeenCalled();
 
-            expect(tokenStorageSpy.storeTokens).toHaveBeenCalledWith(tokenResponse);
-            expect(tokenStorageSpy.storeOriginalIdToken).toHaveBeenCalledWith(tokenResponse.idToken);
+            expect(tokenStorageSpy.storeTokens).toHaveBeenCalledWith(
+                tokenResponse
+            );
+            expect(tokenStorageSpy.storeOriginalIdToken).toHaveBeenCalledWith(
+                tokenResponse.idToken
+            );
 
-            expect(eventsSpy.dispatch).toHaveBeenCalledWith(new TokensReadyEvent(tokenResponse));
+            expect(eventsSpy.dispatch).toHaveBeenCalledWith(
+                new TokensReadyEvent(tokenResponse)
+            );
         }));
 
         it('should redirect to original state using router', fakeAsync(() => {
-
             const state = 'state';
             const code = 'code';
             const sessionState = 'session-state';
             const error = null;
 
-            tokenUrlSpy.parseAuthorizeCallbackParamsFromUrl
-                .and.returnValue({
-                    code,
-                    state,
-                    sessionState,
-                    error
-                });
+            tokenUrlSpy.parseAuthorizeCallbackParamsFromUrl.and.returnValue({
+                code,
+                state,
+                sessionState,
+                error
+            });
 
             const doc: Partial<DiscoveryDocument> = {};
 
@@ -650,9 +716,13 @@ describe('OidcCodeFlowClientService', () => {
                 codeVerifier: 'verifier'
             };
 
-            tokenStorageSpy.storeAuthorizationCode.and.returnValue(of(freshState as any));
+            tokenStorageSpy.storeAuthorizationCode.and.returnValue(
+                of(freshState as any)
+            );
 
-            tokenStorageSpy.clearPreAuthorizationState.and.returnValue(of({} as any));
+            tokenStorageSpy.clearPreAuthorizationState.and.returnValue(
+                of({} as any)
+            );
             tokenStorageSpy.storeTokens.and.returnValue(of({} as any));
             tokenStorageSpy.storeOriginalIdToken.and.returnValue(of({} as any));
 
@@ -668,16 +738,17 @@ describe('OidcCodeFlowClientService', () => {
 
             tokenEndpointSpy.call.and.returnValue(of(tokenResponse));
 
-            const changeUrlSpy = spyOn(codeFlowClient as any, 'historyChangeUrl')
-                .and.returnValue(null);
+            const changeUrlSpy = spyOn(
+                codeFlowClient as any,
+                'historyChangeUrl'
+            ).and.returnValue(null);
 
-            codeFlowClient.currentWindowCodeFlowCallback()
-                .subscribe();
+            codeFlowClient.currentWindowCodeFlowCallback().subscribe();
             flush();
 
-            expect(changeUrlSpy).toHaveBeenCalledWith(localState.preRedirectUrl);
+            expect(changeUrlSpy).toHaveBeenCalledWith(
+                localState.preRedirectUrl
+            );
         }));
-
     });
-
 });

--- a/projects/angular-simple-oidc/src/lib/oidc-code-flow-client.service.ts
+++ b/projects/angular-simple-oidc/src/lib/oidc-code-flow-client.service.ts
@@ -8,7 +8,7 @@ import {
     AuthorizationCallbackFormatError,
     LocalState,
     TokenRequestResult,
-    CreateAuthorizeUrlParams,
+    CreateAuthorizeUrlParams
 } from 'angular-simple-oidc/core';
 import { urlJoin } from './utils/url-join';
 import { OidcDiscoveryDocClient } from './discovery-document/oidc-discovery-doc-client.service';
@@ -37,57 +37,87 @@ export class OidcCodeFlowClient {
         protected readonly tokenEndpointClient: TokenEndpointClientService,
         protected readonly events: EventsService,
         protected readonly dynamicIframe: DynamicIframeService
-    ) { }
+    ) {}
 
-    public startCodeFlow(options: StartCodeFlowParameters = {}): Observable<LocalState> {
+    public startCodeFlow(
+        options: StartCodeFlowParameters = {}
+    ): Observable<LocalState> {
         const opts: StartCodeFlowParameters = {
-            ...options,
+            ...options
         };
 
         if (!opts.returnUrlAfterCallback) {
             opts.returnUrlAfterCallback = this.window.location.href;
         }
 
-        return this.config.current$
-            .pipe(
-                map(config => urlJoin(config.baseUrl, config.tokenCallbackRoute)),
-                switchMap(redirectUri => this.generateCodeFlowMetadata({ redirectUri })),
-                tap(() => this.events.dispatch(new SimpleOidcInfoEvent(`Starting Code Flow`))),
-                switchMap((result) => {
-                    this.events.dispatch(new SimpleOidcInfoEvent(`Authorize URL generated`, result));
-                    return this.tokenStorage.storePreAuthorizationState({
+        return this.config.current$.pipe(
+            map((config) => urlJoin(config.baseUrl, config.tokenCallbackRoute)),
+            switchMap((redirectUri) =>
+                this.generateCodeFlowMetadata({ redirectUri })
+            ),
+            tap(() =>
+                this.events.dispatch(
+                    new SimpleOidcInfoEvent(`Starting Code Flow`)
+                )
+            ),
+            switchMap((result) => {
+                this.events.dispatch(
+                    new SimpleOidcInfoEvent(`Authorize URL generated`, result)
+                );
+                return this.tokenStorage
+                    .storePreAuthorizationState({
                         nonce: result.nonce,
                         state: result.state,
                         codeVerifier: result.codeVerifier,
                         preRedirectUrl: opts.returnUrlAfterCallback
-                    }).pipe(tap((state) => {
-                        this.events.dispatch(new SimpleOidcInfoEvent(`Pre-authorize state stored`, state));
-                        this.redirectToUrl(result.url);
-                    }));
-                }),
-                take(1)
-            );
+                    })
+                    .pipe(
+                        tap((state) => {
+                            this.events.dispatch(
+                                new SimpleOidcInfoEvent(
+                                    `Pre-authorize state stored`,
+                                    state
+                                )
+                            );
+                            if (opts.openWindowHandler) {
+                                opts.openWindowHandler(result.url);
+                            } else {
+                                this.redirectToUrl(result.url);
+                            }
+                        })
+                    );
+            }),
+            take(1)
+        );
     }
 
     public generateCodeFlowMetadata(
-        params: Omit<CreateAuthorizeUrlParams, 'clientId' | 'scope' | 'responseType'>) {
-        return this.discoveryDocumentClient.current$
-            .pipe(
-                withLatestFrom(this.config.current$),
-                map(([discoveryDocument, config]) => this.tokenUrl.createAuthorizeUrl(
-                    discoveryDocument.authorization_endpoint, {
-                    clientId: config.clientId,
-                    scope: config.scope,
-                    responseType: 'code',
-                    ...params,
-                })),
-                take(1),
-            );
+        params: Omit<
+            CreateAuthorizeUrlParams,
+            'clientId' | 'scope' | 'responseType'
+        >
+    ) {
+        return this.discoveryDocumentClient.current$.pipe(
+            withLatestFrom(this.config.current$),
+            map(([discoveryDocument, config]) =>
+                this.tokenUrl.createAuthorizeUrl(
+                    discoveryDocument.authorization_endpoint,
+                    {
+                        clientId: config.clientId,
+                        scope: config.scope,
+                        responseType: 'code',
+                        ...params
+                    }
+                )
+            ),
+            take(1)
+        );
     }
 
     public parseCodeFlowCallbackParams(href: string) {
         try {
-            const result = this.tokenUrl.parseAuthorizeCallbackParamsFromUrl(href);
+            const result =
+                this.tokenUrl.parseAuthorizeCallbackParamsFromUrl(href);
             return { ...result, href };
         } catch (error) {
             throw new AuthorizationCallbackFormatError(error);
@@ -95,122 +125,183 @@ export class OidcCodeFlowClient {
     }
 
     public validateCodeFlowCallback(
-        params: { href: string, code: string, state: string, error: string },
-        localState: string) {
-
+        params: { href: string; code: string; state: string; error: string },
+        localState: string
+    ) {
         const { href, code, state, error } = params;
 
-        this.events.dispatch(new SimpleOidcInfoEvent(`Validating URL params`,
-            { code, state, error, href }));
-        this.tokenValidation.validateAuthorizeCallbackFormat(code, state, error, href);
+        this.events.dispatch(
+            new SimpleOidcInfoEvent(`Validating URL params`, {
+                code,
+                state,
+                error,
+                href
+            })
+        );
+        this.tokenValidation.validateAuthorizeCallbackFormat(
+            code,
+            state,
+            error,
+            href
+        );
 
-        this.events.dispatch(new SimpleOidcInfoEvent(`Validating state vs local state`,
-            { localState, state }));
+        this.events.dispatch(
+            new SimpleOidcInfoEvent(`Validating state vs local state`, {
+                localState,
+                state
+            })
+        );
 
         this.tokenValidation.validateAuthorizeCallbackState(localState, state);
 
-        this.events.dispatch(new SimpleOidcInfoEvent(`Obtained authorization code.`,
-            { code, state }));
+        this.events.dispatch(
+            new SimpleOidcInfoEvent(`Obtained authorization code.`, {
+                code,
+                state
+            })
+        );
     }
 
     public codeFlowCallback(
         href: string,
         redirectUri: string,
-        metadata: { state: string, nonce: string, codeVerifier: string }) {
-
+        metadata: { state: string; nonce: string; codeVerifier: string }
+    ) {
         const params = this.parseCodeFlowCallbackParams(href);
         this.validateCodeFlowCallback(params, metadata.state);
 
-        return this.tokenStorage.storeAuthorizationCode(params.code, params.sessionState)
+        return this.tokenStorage
+            .storeAuthorizationCode(params.code, params.sessionState)
             .pipe(
                 switchMap(() => this.config.current$),
-                switchMap(authConfig => {
-                    const payload = this.tokenUrl.createAuthorizationCodeRequestPayload({
-                        clientId: authConfig.clientId,
-                        clientSecret: authConfig.clientSecret,
-                        scope: authConfig.scope,
-                        redirectUri,
-                        code: params.code,
-                        codeVerifier: metadata.codeVerifier,
-                    });
+                switchMap((authConfig) => {
+                    const payload =
+                        this.tokenUrl.createAuthorizationCodeRequestPayload({
+                            clientId: authConfig.clientId,
+                            clientSecret: authConfig.clientSecret,
+                            scope: authConfig.scope,
+                            redirectUri,
+                            code: params.code,
+                            codeVerifier: metadata.codeVerifier
+                        });
 
-                    return this.requestTokenWithAuthCode(payload, metadata.nonce);
+                    return this.requestTokenWithAuthCode(
+                        payload,
+                        metadata.nonce
+                    );
                 })
             );
     }
 
     public currentWindowCodeFlowCallback(): Observable<TokenRequestResult> {
-        return this.tokenStorage.currentState$
-            .pipe(
-                take(1), // we will be trigger currentState$ below
-                tap(() => this.events.dispatch(new SimpleOidcInfoEvent(`Starting Code Flow callback`))),
-                withLatestFrom(this.config.current$),
-                map(([localState, config]) => {
-                    const redirectUri = urlJoin(config.baseUrl, config.tokenCallbackRoute);
-                    return {
-                        localState,
-                        redirectUri
-                    };
-                }),
-                switchMap(({ localState, redirectUri }) =>
-                    this.codeFlowCallback(this.window.location.href, redirectUri, localState).pipe(
-                        tap(() => this.historyChangeUrl(localState.preRedirectUrl))
-                    )),
-                take(1),
-            );
+        return this.tokenStorage.currentState$.pipe(
+            take(1), // we will be trigger currentState$ below
+            tap(() =>
+                this.events.dispatch(
+                    new SimpleOidcInfoEvent(`Starting Code Flow callback`)
+                )
+            ),
+            withLatestFrom(this.config.current$),
+            map(([localState, config]) => {
+                const redirectUri = urlJoin(
+                    config.baseUrl,
+                    config.tokenCallbackRoute
+                );
+                return {
+                    localState,
+                    redirectUri
+                };
+            }),
+            switchMap(({ localState, redirectUri }) =>
+                this.codeFlowCallback(
+                    this.window.location.href,
+                    redirectUri,
+                    localState
+                ).pipe(
+                    tap(() => this.historyChangeUrl(localState.preRedirectUrl))
+                )
+            ),
+            take(1)
+        );
     }
 
-    public requestTokenWithAuthCode(payload: string, nonce: string): Observable<TokenRequestResult> {
-
+    public requestTokenWithAuthCode(
+        payload: string,
+        nonce: string
+    ): Observable<TokenRequestResult> {
         // The discovery document for issuer
-        const discoveryDocument$ = this.discoveryDocumentClient.current$
-            .pipe(take(1));
+        const discoveryDocument$ = this.discoveryDocumentClient.current$.pipe(
+            take(1)
+        );
 
         // JWT Keys to validate id token signature
-        const jwtKeys$ = this.discoveryDocumentClient.jwtKeys$
-            .pipe(take(1));
+        const jwtKeys$ = this.discoveryDocumentClient.jwtKeys$.pipe(take(1));
 
-        return this.tokenEndpointClient.call(payload)
-            .pipe(
-                tap(() => this.events.dispatch(new SimpleOidcInfoEvent(`Requesting token using authorization code`, payload))),
-                withLatestFrom(discoveryDocument$, jwtKeys$, this.config.current$),
-                take(1),
-                tap(([result, discoveryDocument, jwtKeys, config]) => {
-
-                    this.events.dispatch(new SimpleOidcInfoEvent('Validating identity token..', {
-                        result, nonce, discoveryDocument, jwtKeys
-                    }));
-
-                    this.tokenValidation.validateIdToken(
-                        config.clientId,
-                        result.idToken,
-                        result.decodedIdToken,
+        return this.tokenEndpointClient.call(payload).pipe(
+            tap(() =>
+                this.events.dispatch(
+                    new SimpleOidcInfoEvent(
+                        `Requesting token using authorization code`,
+                        payload
+                    )
+                )
+            ),
+            withLatestFrom(discoveryDocument$, jwtKeys$, this.config.current$),
+            take(1),
+            tap(([result, discoveryDocument, jwtKeys, config]) => {
+                this.events.dispatch(
+                    new SimpleOidcInfoEvent('Validating identity token..', {
+                        result,
                         nonce,
                         discoveryDocument,
-                        jwtKeys,
-                        config.tokenValidation);
-                }),
-                tap(([result]) => {
-                    this.events.dispatch(new SimpleOidcInfoEvent('Validating access token..', result));
-                    this.tokenValidation.validateAccessToken(result.accessToken,
-                        result.decodedIdToken.at_hash);
-                }),
-                switchTap(() => {
-                    this.events.dispatch(new SimpleOidcInfoEvent('Clearing pre-authorize state..'));
-                    return this.tokenStorage.clearPreAuthorizationState();
-                }),
-                switchTap(([result]) => {
-                    this.events.dispatch(new TokensValidatedEvent(result));
-                    this.events.dispatch(new SimpleOidcInfoEvent('Storing tokens..', result));
-                    return this.tokenStorage.storeTokens(result);
-                }),
-                switchTap(([result]) => {
-                    this.events.dispatch(new SimpleOidcInfoEvent('Storing original Identity Token..', result.idToken));
-                    return this.tokenStorage.storeOriginalIdToken(result.idToken);
-                }),
-                map(([result]) => result),
-                tap((result) => this.events.dispatch(new TokensReadyEvent(result))),
-            );
+                        jwtKeys
+                    })
+                );
+
+                this.tokenValidation.validateIdToken(
+                    config.clientId,
+                    result.idToken,
+                    result.decodedIdToken,
+                    nonce,
+                    discoveryDocument,
+                    jwtKeys,
+                    config.tokenValidation
+                );
+            }),
+            tap(([result]) => {
+                this.events.dispatch(
+                    new SimpleOidcInfoEvent('Validating access token..', result)
+                );
+                this.tokenValidation.validateAccessToken(
+                    result.accessToken,
+                    result.decodedIdToken.at_hash
+                );
+            }),
+            switchTap(() => {
+                this.events.dispatch(
+                    new SimpleOidcInfoEvent('Clearing pre-authorize state..')
+                );
+                return this.tokenStorage.clearPreAuthorizationState();
+            }),
+            switchTap(([result]) => {
+                this.events.dispatch(new TokensValidatedEvent(result));
+                this.events.dispatch(
+                    new SimpleOidcInfoEvent('Storing tokens..', result)
+                );
+                return this.tokenStorage.storeTokens(result);
+            }),
+            switchTap(([result]) => {
+                this.events.dispatch(
+                    new SimpleOidcInfoEvent(
+                        'Storing original Identity Token..',
+                        result.idToken
+                    )
+                );
+                return this.tokenStorage.storeOriginalIdToken(result.idToken);
+            }),
+            map(([result]) => result),
+            tap((result) => this.events.dispatch(new TokensReadyEvent(result)))
+        );
     }
 
     protected redirectToUrl(url: string) {
@@ -220,7 +311,9 @@ export class OidcCodeFlowClient {
 
     protected historyChangeUrl(url: string) {
         if (this.window.history) {
-            this.events.dispatch(new SimpleOidcInfoEvent(`Changing URL with history API`, url));
+            this.events.dispatch(
+                new SimpleOidcInfoEvent(`Changing URL with history API`, url)
+            );
             this.window.history.pushState({}, null, url);
         } else {
             this.redirectToUrl(url);


### PR DESCRIPTION
Add to the StartCodeFlow and LogoutFlow parameters an optional callback property for the window handler. This way the window for login/logout can be handled outside of the library.